### PR TITLE
fix: Ensure correct App ID usage for Openfabric connections

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,7 +63,22 @@ def execute(model: AppModel) -> None:
 
     # Initialize the Stub with app IDs
     app_ids = user_config.app_ids if user_config else []
+    logging.info(f"Initializing Stub with app_ids: {app_ids}")
     stub = Stub(app_ids)
+
+    # Define App IDs from configuration
+    text_to_image_app_id = None
+    image_to_3d_app_id = None
+
+    if len(app_ids) >= 2:
+        text_to_image_app_id = app_ids[0]
+        image_to_3d_app_id = app_ids[1]
+        logging.info(f"Text-to-Image App ID: {text_to_image_app_id}")
+        logging.info(f"Image-to-3D App ID: {image_to_3d_app_id}")
+    else:
+        logging.error("Not enough app_ids configured. Expected at least 2 for Text-to-Image and Image-to-3D.")
+        # Further error handling or early return could be implemented here.
+        # For now, calls will fail if IDs are None, and this will be logged by conditional checks below.
 
     # ------------------------------
     # TODO : add your magic here
@@ -77,141 +92,160 @@ def execute(model: AppModel) -> None:
 
     # Call Text-to-Image app
     image_data = None
-    try:
-        logging.info("Calling Text-to-Image app...")
-        text_to_image_app_id = "f0997a01-d6d3-a5fe-53d8-561300318557"
-        app_response = stub.call(
-            app_id=text_to_image_app_id,
-            data={'prompt': enhanced_prompt},
-            uid='super-user'
-        )
-        if app_response:
-            image_data = app_response.get('result')
-            if image_data:
-                logging.info(f"Image data type: {type(image_data)}")
-                logging.info(f"Image data size (approx): {len(image_data) if isinstance(image_data, (str, bytes)) else 'N/A'}")
+    if text_to_image_app_id:
+        try:
+            logging.info(f"Attempting to call Text-to-Image app. Target App ID: {text_to_image_app_id}. Available connections: {list(stub._connections.keys()) if stub._connections else 'No connections'}")
+            # logging.info(f"Calling Text-to-Image app with ID: {text_to_image_app_id}...") # Original log, can be removed or kept
+            app_response = stub.call(
+                app_id=text_to_image_app_id,
+                data={'prompt': enhanced_prompt},
+                uid='super-user'
+            )
+            if app_response:
+                image_data = app_response.get('result')
+                if image_data:
+                    logging.info(f"Image data type: {type(image_data)}")
+                    logging.info(f"Image data size (approx): {len(image_data) if isinstance(image_data, (str, bytes)) else 'N/A'}")
 
-                # Save image data
-                try:
-                    # Attempt to decode if base64, otherwise write raw bytes
-                    if isinstance(image_data, str):
-                        # Remove potential data URI prefix if present (e.g., "data:image/png;base64,")
-                        if ',' in image_data:
-                            image_data = image_data.split(',', 1)[1]
-                        img_bytes = base64.b64decode(image_data)
-                    elif isinstance(image_data, bytes):
-                        img_bytes = image_data
-                    else:
-                        raise TypeError("Unsupported image data type")
+                    # Save image data
+                    try:
+                        # Attempt to decode if base64, otherwise write raw bytes
+                        if isinstance(image_data, str):
+                            # Remove potential data URI prefix if present (e.g., "data:image/png;base64,")
+                            if ',' in image_data:
+                                image_data = image_data.split(',', 1)[1]
+                            img_bytes = base64.b64decode(image_data)
+                        elif isinstance(image_data, bytes):
+                            img_bytes = image_data
+                        else:
+                            raise TypeError("Unsupported image data type")
 
-                    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S_%f')
-                    image_filename = f"image_{timestamp}.png"
-                    image_save_path = os.path.join("generated_assets", image_filename)
+                        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S_%f')
+                        image_filename = f"image_{timestamp}.png"
+                        image_save_path = os.path.join("generated_assets", image_filename)
 
-                    with open(image_save_path, 'wb') as f:
-                        f.write(img_bytes)
-                    logging.info(f"Image saved to {image_save_path}")
-                    response.image_path = image_save_path  # Set image path in response
-                    session_data['generated_image_path'] = response.image_path # Store in session
-                except (base64.binascii.Error, TypeError, FileNotFoundError) as e:
-                    logging.error(f"Error saving image: {e}")
-                    image_data = None # Ensure image_data is None if saving failed
-                    response.image_path = None # Ensure path is None if saving failed
-                    if 'generated_image_path' in session_data: # Clean up session data if saving failed
-                        del session_data['generated_image_path']
+                        with open(image_save_path, 'wb') as f:
+                            f.write(img_bytes)
+                        logging.info(f"Image saved to {image_save_path}")
+                        response.image_path = image_save_path  # Set image path in response
+                        session_data['generated_image_path'] = response.image_path # Store in session
+                    except (base64.binascii.Error, TypeError, FileNotFoundError) as e:
+                        logging.error(f"Error saving image: {e}")
+                        image_data = None # Ensure image_data is None if saving failed
+                        response.image_path = None # Ensure path is None if saving failed
+                        if 'generated_image_path' in session_data: # Clean up session data if saving failed
+                            del session_data['generated_image_path']
+                else:
+                    logging.warning("No 'result' field in Text-to-Image app response.")
             else:
-                logging.warning("No 'result' field in Text-to-Image app response.")
-        else:
-            logging.warning("Text-to-Image app call returned no response.")
-    except Exception as e:
-        logging.error(f"Error calling Text-to-Image app: {e}")
-        image_data = None # Ensure image_data is None if T2I call failed
+                logging.warning("Text-to-Image app call returned no response.")
+        except Exception as e:
+            logging.error(f"Error calling Text-to-Image app: {e}")
+            image_data = None # Ensure image_data is None if T2I call failed
+    else:
+        logging.error("Text-to-Image app ID is not configured. Skipping Text-to-Image call.")
+        # Initialize response message parts to indicate failure early
+        response_message_parts = [f"Echo: {enhanced_prompt}. Text-to-Image app ID not configured."]
 
-    # Initialize response message parts
-    response_message_parts = [f"Echo: {enhanced_prompt}."]
+
+    # Initialize response message parts - moved here to handle T2I failure message
+    if 'response_message_parts' not in locals(): # if not set by early T2I failure
+        response_message_parts = [f"Echo: {enhanced_prompt}."]
+        if not image_data and text_to_image_app_id : # If T2I app was called but failed to produce image_data
+             response_message_parts.append("Failed to generate image.")
+
 
     if response.image_path: # Check if image was successfully saved
         response_message_parts = [f"Image generated for prompt: '{request.prompt}'. Saved as {response.image_path}."]
 
         # Call Image-to-3D app
         model_data = None
-        try:
-            logging.info("Proceeding to Image-to-3D conversion...")
-            image_to_3d_app_id = "69543f29-4d41-4afc-7f29-3d51591f11eb"
+        if image_to_3d_app_id: # This condition already checks if image_to_3d_app_id is not None
+            try:
+                # The condition "image_data_for_3d" from prompt can be inferred if response.image_path exists,
+                # as that's when we proceed. The outer 'if response.image_path:' handles this.
+                logging.info(f"Attempting to call Image-to-3D app. Target App ID: {image_to_3d_app_id}. Available connections: {list(stub._connections.keys()) if stub._connections else 'No connections'}")
+                # logging.info(f"Proceeding to Image-to-3D conversion with ID: {image_to_3d_app_id}...") # Original log
 
-            # Prepare input for Image-to-3D app
-            # We need to pass the raw image bytes, not the base64 string if it was decoded.
-            # The image_data variable currently holds the original response from the T2I app.
-            # We need to ensure we are sending the correct format (raw bytes or base64 string as expected by the I23D app)
-            # For now, let's assume the I23D app expects a base64 encoded string if image_data is a string,
-            # or raw bytes if image_data is bytes. This aligns with how we handled saving.
+                # Prepare input for Image-to-3D app
+                # We need to pass the raw image bytes, not the base64 string if it was decoded.
+                # The image_data variable currently holds the original response from the T2I app.
+                # We need to ensure we are sending the correct format (raw bytes or base64 string as expected by the I23D app)
+                # For now, let's assume the I23D app expects a base64 encoded string if image_data is a string,
+                # or raw bytes if image_data is bytes. This aligns with how we handled saving.
 
-            image_input_for_3d = image_data # This could be str (base64) or bytes
-            if isinstance(image_data, str):
-                 # If it's a string, ensure it's the base64 part without data URI
-                if ',' in image_data:
-                    image_input_for_3d = image_data.split(',', 1)[1]
+                image_input_for_3d = image_data # This could be str (base64) or bytes
+                if isinstance(image_data, str):
+                     # If it's a string, ensure it's the base64 part without data URI
+                    if ',' in image_data:
+                        image_input_for_3d = image_data.split(',', 1)[1]
 
-            input_3d = {'image': image_input_for_3d}
+                input_3d = {'image': image_input_for_3d}
 
-            logging.info(f"Calling Image-to-3D app with image data type: {type(image_input_for_3d)}")
+                # logging.info(f"Calling Image-to-3D app with image data type: {type(image_input_for_3d)}") # Original log
 
-            app_3d_response = stub.call(
-                app_id=image_to_3d_app_id,
-                data=input_3d,
-                uid='super-user'
-            )
+                app_3d_response = stub.call(
+                    app_id=image_to_3d_app_id,
+                    data=input_3d,
+                    uid='super-user'
+                )
 
-            if app_3d_response:
-                model_data = app_3d_response.get('result')
-                if model_data:
-                    logging.info(f"3D model data type: {type(model_data)}")
-                    logging.info(f"3D model data size (approx): {len(model_data) if isinstance(model_data, (str, bytes)) else 'N/A'}")
+                if app_3d_response:
+                    model_data = app_3d_response.get('result')
+                    if model_data:
+                        logging.info(f"3D model data type: {type(model_data)}")
+                        logging.info(f"3D model data size (approx): {len(model_data) if isinstance(model_data, (str, bytes)) else 'N/A'}")
 
-                    # Save 3D model data
-                    try:
-                        # Assuming model_data is bytes or base64 string
-                        if isinstance(model_data, str):
-                            # Remove potential data URI prefix if present
-                            if ',' in model_data:
-                                model_data = model_data.split(',', 1)[1]
-                            model_bytes = base64.b64decode(model_data)
-                        elif isinstance(model_data, bytes):
-                            model_bytes = model_data
-                        else:
-                            raise TypeError("Unsupported model data type for saving")
+                        # Save 3D model data
+                        try:
+                            # Assuming model_data is bytes or base64 string
+                            if isinstance(model_data, str):
+                                # Remove potential data URI prefix if present
+                                if ',' in model_data:
+                                    model_data = model_data.split(',', 1)[1]
+                                model_bytes = base64.b64decode(model_data)
+                            elif isinstance(model_data, bytes):
+                                model_bytes = model_data
+                            else:
+                                raise TypeError("Unsupported model data type for saving")
 
-                    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S_%f')
-                    model_filename = f"model_{timestamp}.glb"
-                    model_save_path = os.path.join("generated_assets", model_filename)
+                        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S_%f')
+                        model_filename = f"model_{timestamp}.glb"
+                        model_save_path = os.path.join("generated_assets", model_filename)
 
-                    with open(model_save_path, 'wb') as f:
-                        f.write(model_bytes)
-                    logging.info(f"3D model saved to {model_save_path}")
-                    response.model_path = model_save_path # Set model path in response
-                    session_data['generated_model_path'] = response.model_path # Store in session
-                    response_message_parts.append(f"3D model generated and saved as {response.model_path}.")
-                    except (base64.binascii.Error, TypeError, FileNotFoundError) as e:
-                        logging.error(f"Error saving 3D model: {e}")
-                        response_message_parts.append("Failed to save 3D model.")
-                        response.model_path = None # Ensure path is None if saving failed
-                        if 'generated_model_path' in session_data: # Clean up session data if saving failed
-                            del session_data['generated_model_path']
+                        with open(model_save_path, 'wb') as f:
+                            f.write(model_bytes)
+                        logging.info(f"3D model saved to {model_save_path}")
+                        response.model_path = model_save_path # Set model path in response
+                        session_data['generated_model_path'] = response.model_path # Store in session
+                        response_message_parts.append(f"3D model generated and saved as {response.model_path}.")
+                        except (base64.binascii.Error, TypeError, FileNotFoundError) as e:
+                            logging.error(f"Error saving 3D model: {e}")
+                            response_message_parts.append("Failed to save 3D model.")
+                            response.model_path = None # Ensure path is None if saving failed
+                            if 'generated_model_path' in session_data: # Clean up session data if saving failed
+                                del session_data['generated_model_path']
+                    else:
+                        logging.warning("No 'result' field in Image-to-3D app response.")
+                        response_message_parts.append("Image-to-3D app returned no model data.")
                 else:
-                    logging.warning("No 'result' field in Image-to-3D app response.")
-                    response_message_parts.append("Image-to-3D app returned no model data.")
-            else:
-                logging.warning("Image-to-3D app call returned no response.")
-                response_message_parts.append("Image-to-3D app call failed.")
-        except Exception as e:
-            logging.error(f"Error calling Image-to-3D app: {e}")
-            response_message_parts.append(f"Error during Image-to-3D conversion: {e}.")
-    elif not image_data: # This means T2I failed before saving attempt or image_data was explicitly set to None
+                    logging.warning("Image-to-3D app call returned no response.")
+                    response_message_parts.append("Image-to-3D app call failed.")
+            except Exception as e:
+                logging.error(f"Error calling Image-to-3D app: {e}")
+                response_message_parts.append(f"Error during Image-to-3D conversion: {e}.")
+        else:
+            logging.warning("Image-to-3D app ID is not configured. Skipping Image-to-3D call.")
+            response_message_parts.append("Image-to-3D app ID not configured, 3D model step skipped.")
+
+    elif not image_data and text_to_image_app_id : # This means T2I was called but failed to produce image_data
         response_message_parts = [f"Echo: {enhanced_prompt}. Failed to generate image, so Image-to-3D step skipped."]
+    elif not text_to_image_app_id: # This means T2I was never called due to missing ID
+        # Message already set by the T2I block's else condition
+        pass
 
     # Log session data (short-term memory)
     logging.info(f"Short-term memory for this session: {session_data}")
-
     # Save session data to file if image was generated (long-term memory)
     if session_data.get('generated_image_path'):
         try:


### PR DESCRIPTION
Corrects an issue where Openfabric app calls could fail with a "Connection not found" error. The `Stub` was potentially not being initialized with the specific app IDs that were later used in `stub.call()`.

Changes include:
- Verified that `config/execution.json` is correctly structured and contains the specific app IDs for Text-to-Image (f0997a01-d6d3-a5fe-53d8-561300318557) and Image-to-3D (69543f29-4d41-4afc-7f29-3d51591f11eb).
- Added logging in `main.py` to show the `app_ids` being used for `Stub` initialization.
- Modified `main.py` to dynamically use the app IDs from the `user_config.app_ids` list when calling `stub.call()`, rather than hardcoding them. Assumes the first ID is for Text-to-Image and the second for Image-to-3D.
- Enhanced logging before each `stub.call()` to show the target App ID and the list of available connections in the `Stub`, aiding in debugging connection issues.

These changes ensure that the `Stub` is aware of the specific app IDs it needs to connect to, and that the calls are directed to these configured IDs.